### PR TITLE
Add files to deploy to a k8s cluster

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mlops-team-7
+  namespace: mlops
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mlops-team-7
+  template:
+    metadata:
+      labels:
+        app: mlops-team-7
+    spec:
+      containers:
+      - name: mlops-team-7
+        image: ealen/echo-server:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+          - containerPort: 80
+        env:
+          - name: PORT
+            value: "80"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -17,8 +17,9 @@ spec:
     spec:
       containers:
       - name: mlops-team-7
-        image: ealen/echo-server:latest
-        imagePullPolicy: IfNotPresent
+        image: rgalindowl/mlops-bootcamp-team7:latest
+        command: ["/bin/bash", "-c"]
+        args: ["uvicorn src.main:app --reload --host 0.0.0.0 --port 80"]
         ports:
           - containerPort: 80
         env:

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mlops-team-7
+  namespace: mlops
+  annotations:
+    external-dns.alpha.kubernetes.io: enable
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: mlops.os.wizeline.io
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: mlops-team-7
+            port:
+              number: 80

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mlops

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mlops-team-7
+  namespace: mlops
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: ClusterIP
+  selector:
+    app: mlops-team-7


### PR DESCRIPTION
Service is expected to be available at `mlops.os.wizeline.io`.
For simplicity, we should build the container image and upload it to DockerHub. Before to merge/deploy this files, we need to change the container image in the `deployment.yaml` file with the image from DockerHub.

To apply changes run the next command: `kubectl apply -f namespace.yaml -f deployment.yaml -f service.yaml -f ingress.yaml`
To remove resources, run: `kubectl delete -f ingress.yaml -f service.yaml -f deployment.yaml -f namespace.yaml`